### PR TITLE
maven dependency issue fix

### DIFF
--- a/spring-projections/pom.xml
+++ b/spring-projections/pom.xml
@@ -66,6 +66,13 @@
 					<target>1.8</target>
 				</configuration>
 			</plugin>
+
+			<!-- Package as an executable jar -->
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+
 		</plugins>
 	</build>
 	<repositories>
@@ -83,5 +90,16 @@
 		</repository>
 
 	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>spring-snapshots</id>
+			<url>http://repo.spring.io/snapshot</url>
+		</pluginRepository>
+		<pluginRepository>
+			<id>spring-milestones</id>
+			<url>http://repo.spring.io/milestone</url>
+		</pluginRepository>
+	</pluginRepositories>
 
 </project>

--- a/spring-projections/pom.xml
+++ b/spring-projections/pom.xml
@@ -23,6 +23,7 @@
 	</parent>
 
 	<dependencies>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
@@ -75,9 +76,11 @@
 			<url>http://repo.springsource.org/snapshot</url>
 		</repository>
 
-
-
-
+		<repository>
+			<id>repository.springsource.milestones</id>
+			<name>SpringSource Milestone Repository</name>
+			<url>http://repo.springsource.org/milestone</url>
+		</repository>
 
 	</repositories>
 

--- a/spring-projections/readme.md
+++ b/spring-projections/readme.md
@@ -14,8 +14,7 @@ From the command line do:
 ```
 git clone https://github.com/Thinkenterprise/spring-projections.git
 cd spring-projections
-mvn clean package
-java -jar target/*.jar
+mvn clean package spring-boot:run
 ```
 
 Root Resources:


### PR DESCRIPTION
Add milestone repository to resolve spring milestone releases (e. g. spring-integration-bom:pom:4.2.0.M2) which seems to be required since the Gosling-RC1 and occurred suddenly due to the usage of the spring boot snapshot version.

Add spring boot maven plugin as well as the corresponding repositories to package an executable jar (which could launched via the maven goal "spring-boot:run").
